### PR TITLE
Fixed a bug that caused the snake to accelerate until an exception occurred.

### DIFF
--- a/Snake/Program.cs
+++ b/Snake/Program.cs
@@ -58,11 +58,14 @@ namespace Snake
                 // Elapsed time for processing the frame
                 stopwatch.Stop();
                 int elapsed = (int)stopwatch.ElapsedMilliseconds;
-                
+
                 // Frame timing
                 Thread.Sleep((1000 / 6) - elapsed);
+
+                //resets stopwatch to 0
+                stopwatch.Reset();
             }
-            
+
             Global.GameBoard.Close();
             Console.WriteLine($"Your score: {Global.GameBoard.PlayerScore}");
         }


### PR DESCRIPTION
The stopwatch in the main function didn't reset its value, and, combined with line 63's Thread.Sleep, compounded into a Thread.Sleep(negative number), causing an exception.